### PR TITLE
Restyle admin dashboard with Apple-inspired palette

### DIFF
--- a/Apple.html
+++ b/Apple.html
@@ -3,469 +3,283 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Apple.com</title>
+    <title> Admin Dashboard</title>
     <link rel="stylesheet" href="apple.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@200&family=Open+Sans:wght@300&family=Roboto:wght@100;300&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@200&family=Open+Sans&family=Roboto:wght@100;300&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@200&family=Roboto:wght@100;300&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@100;300&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@100&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.css" integrity="sha512-tx5+1LWHez1QiaXlAyDwzdBTfDjX07GMapQoFTS74wkcPMsI3So0KYmFe6EHZjI8+eSG0ljBlAQc3PQ5BTaZtQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-yH0RzEukgqS0bkkCm1cW0XkyRjO6jwxKF1u9IiMaTZGi99ZTSdK6Ff8gDuwZQzQpimeISFRCGDpa2BkLomPvA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
-    <div class="wrapper">
-        <header class="nav-bar">
-            <div class="navcontent">
-                <div class="nav-belt">
-                  <div class="nav-logo">
-                    <img src="Applelogo.png" alt="">
-                  </div>
-                  <div class="nav-cont">Store</div>
-                  <div class="nav-cont">Mac</div>
-                  <div class="nav-cont">iphone</div>
-                  <div class="nav-cont">ipad</div>
-                  <div class="nav-cont">Watch</div>
-                  <div class="nav-cont">Airpods</div>
-                  <div class="nav-cont">TV & Home</div>
-                  <div class="nav-cont">Entertainment</div>
-                  <div class="nav-cont">Accessories</div>
-                  <div class="nav-cont">Support</div>
-                  <div class="nav-search">
-                    <img src="Applesearchlogo.png" alt="">
-                  </div>
-                  <div class="nav-shop">
-                    <img src="Applelogoshop.png">
-                  </div>
-                  </div>
+    <div class="dashboard">
+        <aside class="sidebar">
+            <div class="brand">
+                <i class="fa-brands fa-apple"></i>
+                <span>Apple Operations</span>
             </div>
+            <nav class="sidebar-nav">
+                <a href="#" class="nav-item active"><i class="fa-solid fa-gauge"></i>Overview</a>
+                <a href="#" class="nav-item"><i class="fa-solid fa-store"></i>Retail performance</a>
+                <a href="#" class="nav-item"><i class="fa-solid fa-box"></i>Supply chain</a>
+                <a href="#" class="nav-item"><i class="fa-solid fa-mobile-screen"></i>Devices</a>
+                <a href="#" class="nav-item"><i class="fa-solid fa-headset"></i>Customer care</a>
+                <a href="#" class="nav-item"><i class="fa-solid fa-gear"></i>Settings</a>
+            </nav>
+            <div class="sidebar-upgrade">
+                <p class="upgrade-title">Need more insight?</p>
+                <p class="upgrade-body">Enable executive highlights to see launch readiness, global stock, and store sentiment in one view.</p>
+                <button class="upgrade-btn">Activate highlights</button>
             </div>
-            
-        </header>
+        </aside>
 
-        <div class="main">
-            <div class="main-info">
-                <div class="main-info-count">
-                    <p class="m-5 ">Save up to ₹8000.00 instantly on eligible products with HDFC Bank Credit Cards.* Plus No Cost EMI from most leading banks.</p><a>  Shop now</a>
+        <main class="main-content">
+            <header class="topbar">
+                <div class="search">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                    <input type="search" placeholder="Search for reports, users, or files">
                 </div>
-            </div>
-            <div class="section">
-                <div class="sec-cont">
-                    <div class="sec-cont-head">
-                        <h1>iPhone 15</h1>
-                        <p> New Camera. New Design. Newphoria.</p>
-                    </div>
-                    <div class="sec-cont-link">
-                        <a class="lm" href="">learn more </a>
-                        <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <g clip-path="url(#clip0_1_127)">
-                            <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                            </g>
-                            <defs>
-                            <clipPath id="clip0_1_127">
-                            <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                            </clipPath>
-                            </defs>
-                        </svg>                                                        
-                        <a class="buy" href="">Buy </a>
-                        <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <g clip-path="url(#clip0_1_127)">
-                            <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                            </g>
-                            <defs>
-                            <clipPath id="clip0_1_127">
-                            <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                            </clipPath>
-                            </defs>
-                        </svg>                           
-                    </div>
-                </div>
-            </div>
-            <div class="section2">
-                <video autoplay muted loop plays-inline id="BGVideo">
-                    <source src="apple vid.mp4" type="video/mp4">
-                </video> 
-                <div class="sec2-overlay p-1 ">
-                    <p class="text-center"> Watch the film</p>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21" fill="none">
-                        <g clip-path="url(#clip0_1_157)">
-                          <path d="M9.34125 16.9323C8.57436 16.9323 7.83368 16.8316 7.11921 16.6302C6.40474 16.4289 5.73302 16.142 5.10407 15.7696C4.47511 15.3972 3.90409 14.9544 3.39099 14.4413C2.87789 13.9282 2.43514 13.3572 2.06273 12.7282C1.69033 12.0993 1.40343 11.4276 1.20206 10.7131C1.00068 9.99862 0.899994 9.25795 0.899994 8.49106C0.899994 7.71866 1.00068 6.9766 1.20206 6.26489C1.40343 5.55317 1.68895 4.88284 2.0586 4.25388C2.42825 3.62493 2.86962 3.0539 3.38271 2.5408C3.89581 2.02771 4.46684 1.58496 5.09579 1.21255C5.72475 0.840141 6.39646 0.553249 7.11093 0.351873C7.82541 0.150497 8.56608 0.0498085 9.33297 0.0498085C10.1054 0.0498085 10.8488 0.150497 11.5633 0.351873C12.2778 0.553249 12.9481 0.840141 13.5743 1.21255C14.2005 1.58496 14.7715 2.02771 15.2874 2.5408C15.8032 3.0539 16.2473 3.62493 16.6198 4.25388C16.9922 4.88284 17.2791 5.55317 17.4804 6.26489C17.6818 6.9766 17.7825 7.71866 17.7825 8.49106C17.7825 9.25795 17.6818 9.99862 17.4804 10.7131C17.2791 11.4276 16.9922 12.0993 16.6198 12.7282C16.2473 13.3572 15.8046 13.9282 15.2915 14.4413C14.7784 14.9544 14.2074 15.3972 13.5784 15.7696C12.9495 16.142 12.2791 16.4289 11.5674 16.6302C10.8557 16.8316 10.1136 16.9323 9.34125 16.9323ZM9.34125 15.5254C10.1247 15.5254 10.8681 15.4082 11.5716 15.1737C12.275 14.9392 12.9191 14.6068 13.5039 14.1765C14.0888 13.7462 14.5963 13.2386 15.0267 12.6538C15.457 12.0689 15.7894 11.4248 16.0239 10.7214C16.2584 10.0179 16.3756 9.2745 16.3756 8.49106C16.3756 7.70762 16.257 6.96419 16.0198 6.26075C15.7825 5.55731 15.4487 4.91318 15.0184 4.32836C14.5881 3.74355 14.0805 3.23597 13.4957 2.80563C12.9108 2.37529 12.2667 2.04288 11.5633 1.8084C10.8598 1.57392 10.1164 1.45668 9.33297 1.45668C8.54953 1.45668 7.80748 1.57392 7.1068 1.8084C6.40612 2.04288 5.76337 2.37529 5.17855 2.80563C4.59373 3.23597 4.08753 3.74355 3.65995 4.32836C3.23237 4.91318 2.90134 5.55731 2.66686 6.26075C2.43238 6.96419 2.31514 7.70762 2.31514 8.49106C2.31514 9.2745 2.43238 10.0179 2.66686 10.7214C2.90134 11.4248 3.23237 12.0689 3.65995 12.6538C4.08753 13.2386 4.59373 13.7462 5.17855 14.1765C5.76337 14.6068 6.4075 14.9392 7.11093 15.1737C7.81437 15.4082 8.55781 15.5254 9.34125 15.5254ZM7.88472 11.5365C7.76334 11.6083 7.64334 11.64 7.52472 11.6317C7.4061 11.6234 7.30679 11.5807 7.22679 11.5034C7.1468 11.4262 7.1068 11.3269 7.1068 11.2055V5.78489C7.1068 5.658 7.14818 5.55869 7.23093 5.48697C7.31369 5.41525 7.41576 5.37525 7.53714 5.36697C7.65851 5.35869 7.77437 5.38766 7.88472 5.45387L12.3205 8.07727C12.4253 8.13796 12.4957 8.2221 12.5315 8.32968C12.5674 8.43727 12.5688 8.54485 12.5357 8.65244C12.5026 8.76002 12.4309 8.84692 12.3205 8.91312L7.88472 11.5365Z" fill="black"/>
-                        </g>
-                        <defs>
-                          <clipPath id="clip0_1_157">
-                            <rect width="19.52" height="20" fill="white" transform="matrix(1 0 0 -1 0.899994 20.08)"/>
-                          </clipPath>
-                        </defs>
-                    </svg>
-                </div>
-                    
-            </div>
-             <div class="section3">
-                <div class="sec-cont3">
-                    <div class="sec-cont-head">
-                        <h1 class="sec3-h">iPhone 15 Pro</h1>
-                        <p class="sec3-p">Titanium. So strong. So light. So Pro.</p>
-                    </div>
-                    <div class="sec-cont-link">
-                        <a class="lm" href="">Learn more </a>
-                        <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <g clip-path="url(#clip0_1_127)">
-                            <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                            </g>
-                            <defs>
-                            <clipPath id="clip0_1_127">
-                            <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                            </clipPath>
-                            </defs>
-                        </svg>                            
-                        <a class="buy" href="">Buy </a>
-                        <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <g clip-path="url(#clip0_1_127)">
-                            <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                            </g>
-                            <defs>
-                            <clipPath id="clip0_1_127">
-                            <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                            </clipPath>
-                            </defs>
-                        </svg>                            
-                    </div>
-                </div>
-            </div>
-            <div class="section4">
-                <div class="box" style="background-image: url('Appleassest5.png');">
-                    <div class="box-cont">
-                        <h1>MacBook Pro</h1>
-                        <p>Mind-blowing. Head-turning.</p>
-                        <div class="sec-cont-link">
-                            <a class="lm"href="" >learn more </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                                
-                            <a class="buy" href="">Buy </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                                
+                <div class="topbar-actions">
+                    <button class="icon-btn" aria-label="Notifications"><i class="fa-regular fa-bell"></i></button>
+                    <button class="icon-btn" aria-label="Toggle theme"><i class="fa-regular fa-moon"></i></button>
+                    <div class="profile">
+                        <img src="https://i.pravatar.cc/100?img=32" alt="User avatar">
+                        <div>
+                            <p class="profile-name">Minh Nguyen</p>
+                            <p class="profile-role">Administrator</p>
                         </div>
                     </div>
                 </div>
-                <div class="box" style="background-image: url('Appleassest6.png');">
-                    <div class="box-cont">
-                        <h1 class="boxh1" style="color: #F5F5F7;" >AirPods Pro</h1>
-                        <p class="boxp" style="color: #F5F5F7;" >Adaptive Audio. Now playing.</p>
-                        <div class="sec-cont-link">
-                            <a class="lm" href="">learn more </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                                
-                            <a class="buy" href="">Buy </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-                <div class="box" style="background-image: url('holiday_2023_promo__dirvdl6a3r2a_small_2x.jpg');">
-                    <div class="box-cont">
-                        <h1>Wonder awaits.</h1>
-                        <p >Give the gifts they've been looking forward to all year</p>
-                        <div class="sec-cont-shop">
-                            <a class="shop p-1" href="">Shop </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-                <div class="box" style="background-image: url('Appleassest3.png');">
-                    <div class="box-cont">
-                        <img src="Applewatchlogo.png">
-                        <p >Next-level adventure.</p>
-                        <div class="sec-cont-link">
-                            <a class="lm" href="">learn more </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                            <a class="buy" href="">Buy </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-                <div class="box" style="background-image: url('Appleassest2.png');">
-                    <div class="box-cont">
-                        <h1>iPad</h1>
-                        <p >Lovable. Drawable. Magical.</p>
-                        <div class="sec-cont-link">
-                            <a class="lm" href="">learn more </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                            <a class="buy" href="">Buy </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-                <div class="box" style="background-image: url('Appleassest1.png');">
-                    <div class="box-cont">
-                        <img src="Appletradelogo.png">
-                        <p >Upgrade and save. It’s that easy.</p>
-                        <div class="sec-cont-shop">
-                            <a class="shop p-1" href="">See what your device is worth </a>
-                            <svg width="11" height="30" viewBox="0 0 11 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0_1_127)">
-                                <path d="M1.59417 20.7218C1.38085 20.7218 1.19849 20.6478 1.0471 20.4999C0.895704 20.3519 0.820007 20.1713 0.820007 19.958C0.820007 19.7446 0.899144 19.5588 1.05742 19.4006L5.2276 15.2407L1.05742 11.0808C0.899144 10.9226 0.820007 10.7368 0.820007 10.5234C0.820007 10.3101 0.895704 10.1295 1.0471 9.98153C1.19849 9.83358 1.38085 9.7596 1.59417 9.7596C1.79374 9.7596 1.97266 9.83186 2.13093 9.97637L6.83786 14.6627C7.00302 14.8141 7.0856 15.0067 7.0856 15.2407C7.0856 15.4609 7.00302 15.6536 6.83786 15.8187L2.13093 20.505C1.98642 20.6495 1.8075 20.7218 1.59417 20.7218Z" fill="#2997FF"/>
-                                </g>
-                                <defs>
-                                <clipPath id="clip0_1_127">
-                                <rect width="9.51" height="29" fill="white" transform="matrix(1 0 0 -1 0.820007 29.7201)"/>
-                                </clipPath>
-                                </defs>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            
-            </div>
-            <div class="section7">
-                <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
-                    <ol class="carousel-indicators">
-                        <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>
-                        <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
-                        <li data-target="#carouselExampleIndicators" data-slide-to="2"></li>
-                    </ol>
-                    <div class="carousel-inner">
-                        <div class="carousel-item active">
-                        <img class="d-block w-100 .active " src="link.png" alt="First slide" >
-                        </div>
-                        <div class="carousel-item">
-                        <img class="d-block w-100" src="Link (1).jpeg" alt="Second slide">
-                        </div>
-                        <div class="carousel-item">
-                        <img class="d-block w-100" src="Link (2).jpeg" alt="Third slide">
-                        </div>
-                    </div>
-                    <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
-                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                        <span class="sr-only">Previous</span>
-                    </a>
-                    <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
-                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                        <span class="sr-only">Next</span>
-                    </a>
-                </div>
-            </div>
-        </div> 
+            </header>
 
-        <footer class="footer">
-            <div class="footer-all">
-                <div class="foot-cont-1">
-                    <p class="p1">*Instant savings, otherwise referred to as instant cashback, is available with the purchase of an eligible product for qualifying HDFC Bank Credit Cards and EasyEMI Credit Cards
-                        only. Minimum transaction value of ₹10001.00 applies. <a href="" >Click here</a> to see instant savings amounts and eligible devices. Instant savings is available for up to two orders per rolling
-                        90-day period with an eligible card. Card eligibility is subject to terms and conditions between you and your card-issuing bank. Total transaction value is calculated after any
-                        trade-in credit or eligible discount applied. Any subsequent order adjustment(s) or cancellation(s) may result in instant savings being recalculated, and any refund may be
-                        adjusted to account for instant savings clawback; this may result in no refund being made to you. Offer may be revised or withdrawn at any time without any prior notice.
-                        <a href="">Additional terms apply</a>. Offer cannot be combined with Apple Store for Education or Corporate Employee Purchase Plan pricing. Multiple separate orders cannot be combined
-                        for instant savings.</p>
-                    <p class="p2">‡No Cost EMI is available with the purchase of an <a href="">eligible product</a> made using eligible cards on 3- or 6-month tenures from most leading banks. Monthly pricing is rounded to
-                        the nearest rupee. Exact pricing will be provided by your bank, subject to your bank’s terms and conditions. Minimum order spend applies as per your card-issuing bank
-                        threshold. Offer cannot be combined with Apple Store for Education or Corporate Employee Purchase Plan pricing. Card eligibility is subject to terms and conditions between
-                        you and your card-issuing bank. Offer may be revised or withdrawn at any time without any prior notice. <a href="">Additional terms apply</a>.
-                    </p>
-                    <p class="p3">Representative example: Based on a 6-month tenure. ₹79900.00 total cost includes 15% p.a. and No Cost EMI savings of ₹3380.00, paid over 6 months as six monthly
-                        payments of ₹13317.00.
-                    </p>
-                    <p  class="p4">A subscription is required for Apple TV+.</p>
+            <section class="welcome">
+                <div>
+                    <span class="product-pill">Spotlight · iPhone 15 Pro Max — Desert Titanium</span>
+                    <h1>Good morning, Minh</h1>
+                    <p>Launch prep metrics, retail velocity, and customer care sentiment refresh every 15 minutes so you can keep focus on the next keynote moment.</p>
                 </div>
-    
-                <div class="foot-count-2">
-                    <ul>
-                        <p>Shop and Learn</p> 
-                        <a>Store</a>
-                        <a>Mac</a>
-                        <a>iPad</a>
-                        <a>iPhone</a>
-                        <a>Watch</a>
-                        <a>AirPods</a>
-                        <a>TV & Home</a>
-                        <a>AirTag</a>
-                        <a>Accessories</a>
-                        <a>Gift Cards</a>
-                        <p>Apple Wallet</p>
-                        <a>Wallet</a>
-                     </ul>
-                     <ul>
-                         <p>Account</p> 
-                         <a>Manage Your Apple ID</a>
-                         <a>Apple Store Account</a>
-                         <a>iCloud.com</a>
-                         <p>Entertainment</p>
-                         <a>Apple One</a>
-                         <a>Apple TV+</a>
-                         <a>Apple Music</a>
-                         <a>Apple Arcade</a>
-                         <a>Apple Podcasts</a>
-                         <a>Apple Books</a>
-                         <a>App Store</a>
-                     </ul>
-                     <ul>
-                         <p>Apple Store</p> 
-                         <a>Find a Store</a>
-                         <a>Genius Bar</a>
-                         <a>Today at Apple</a>
-                         <a>Apple Camp</a>
-                         <a>Apple Trade In</a>
-                         <a>Ways to Buy</a>
-                         <a>Recycling Programme</a>
-                         <a>Order Status</a>
-                         <a>Shopping Help</a>
-                     </ul>
-                     <ul>
-                         <p>For Business</p> 
-                         <a>Apple and Business</a>
-                         <a>Shop for Business</a>
-                         <p>For Education</p>
-                         <a>Apple and Education</a>
-                         <a>Shop for Education</a>
-                         <a>Shop for Universitys</a>
-                         <p>For Healthcare</p>
-                         <a>Apple in Healthcare</a>
-                         <a>Health on Apple Watch</a>
-                     </ul>
-                     <ul>
-                        <p>Apple Values</p>
-                        <a>Accessibility</a>
-                        <a>Education</a>
-                        <a>Environment</a>
-                        <a>Privacy</a>
-                        <a>Supplier Responsibility</a>
-                        <p>About Apple</p>
-                        <a>Newsroom</a>
-                        <a>Apple Leadership</a>
-                        <a>Career Opportunities</a>
-                        <a>Investors</a>
-                        <a>Ethics & Compliance</a>
-                        <a>Events</a>
-                        <a>Contact Apple</a>
-                     </ul>
-    
+                <button class="primary-btn"><i class="fa-solid fa-plus"></i>Schedule briefing</button>
+            </section>
+
+            <section class="stats-grid">
+                <article class="stat-card">
+                    <div class="stat-header">
+                        <p class="stat-title">Retail revenue</p>
+                        <span class="stat-badge positive">+12.4%</span>
+                    </div>
+                    <h2>$248,930</h2>
+                    <p class="stat-caption">Global store revenue vs. $221,380 last cycle</p>
+                    <div class="sparkline">
+                        <div style="height: 40%"></div>
+                        <div style="height: 60%"></div>
+                        <div style="height: 45%"></div>
+                        <div style="height: 80%"></div>
+                        <div style="height: 65%"></div>
+                        <div style="height: 90%"></div>
+                        <div style="height: 75%"></div>
+                    </div>
+                </article>
+                <article class="stat-card">
+                    <div class="stat-header">
+                        <p class="stat-title">Active devices</p>
+                        <span class="stat-badge neutral">+3.1%</span>
+                    </div>
+                    <h2>18,492</h2>
+                    <p class="stat-caption">Daily active Apple IDs across devices</p>
+                    <div class="progress">
+                        <div class="progress-bar" style="width:72%"></div>
+                    </div>
+                </article>
+                <article class="stat-card">
+                    <div class="stat-header">
+                        <p class="stat-title">Support cases</p>
+                        <span class="stat-badge negative">-8.5%</span>
+                    </div>
+                    <h2>126</h2>
+                    <p class="stat-caption">Cases closed in the last 24 hours</p>
+                    <ul class="stat-list">
+                        <li><span class="dot success"></span> 92% first response &lt; 1 hour</li>
+                        <li><span class="dot warning"></span> 6% escalated</li>
+                        <li><span class="dot danger"></span> 2% awaiting customer reply</li>
+                    </ul>
+                </article>
+                <article class="stat-card">
+                    <div class="stat-header">
+                        <p class="stat-title">AppleCare+ sign-ups</p>
+                        <span class="stat-badge positive">+21.6%</span>
+                    </div>
+                    <h2>1,042</h2>
+                    <p class="stat-caption">Net new protection plans in the last 7 days</p>
+                    <div class="subscription-chart">
+                        <div class="bar" style="height:55%"></div>
+                        <div class="bar" style="height:62%"></div>
+                        <div class="bar" style="height:70%"></div>
+                        <div class="bar" style="height:88%"></div>
+                        <div class="bar" style="height:95%"></div>
+                    </div>
+                </article>
+            </section>
+
+            <section class="grid-two">
+                <article class="card analytics-card">
+                    <div class="card-header">
+                        <h3>Store traffic sources</h3>
+                        <button class="icon-btn" aria-label="Download report"><i class="fa-solid fa-download"></i></button>
+                    </div>
+                    <div class="chart-grid">
+                        <div class="chart-legend">
+                            <p><span class="dot success"></span>Apple.com</p>
+                            <p><span class="dot info"></span>Retail partners</p>
+                            <p><span class="dot warning"></span>Paid campaigns</p>
+                            <p><span class="dot danger"></span>Direct walk-in</p>
+                        </div>
+                        <div class="chart-pie">
+                            <div class="pie"></div>
+                            <div class="pie-center">
+                                <span>62%</span>
+                                <small>Organic</small>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="card-footer">Apple.com referrals continue to outpace paid initiatives by 2.4×.</p>
+                </article>
+
+                <article class="card table-card">
+                    <div class="card-header">
+                        <h3>Top performing initiatives</h3>
+                        <a href="#">View all</a>
+                    </div>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Initiative</th>
+                                <th>Owner</th>
+                                <th>Status</th>
+                                <th>Progress</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Apple Store redesign · Singapore</td>
+                                <td>Sarah Tran</td>
+                                <td><span class="status success">On Track</span></td>
+                                <td>
+                                    <div class="progress small">
+                                        <div class="progress-bar" style="width:86%"></div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Trade-in experience revamp</td>
+                                <td>Akira Mori</td>
+                                <td><span class="status warning">At Risk</span></td>
+                                <td>
+                                    <div class="progress small">
+                                        <div class="progress-bar warning" style="width:54%"></div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Retail Today iPad rollout</td>
+                                <td>Oliver Stone</td>
+                                <td><span class="status success">On Track</span></td>
+                                <td>
+                                    <div class="progress small">
+                                        <div class="progress-bar" style="width:72%"></div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Partner portal localization</td>
+                                <td>Linh Pham</td>
+                                <td><span class="status info">Review</span></td>
+                                <td>
+                                    <div class="progress small">
+                                        <div class="progress-bar info" style="width:41%"></div>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </article>
+            </section>
+
+            <section class="grid-two">
+                <article class="card activity-card">
+                    <div class="card-header">
+                        <h3>Team activity</h3>
+                        <button class="icon-btn" aria-label="Filter activity"><i class="fa-solid fa-sliders"></i></button>
+                    </div>
+                    <ul class="activity-list">
+                        <li>
+                            <span class="avatar" aria-hidden="true">ST</span>
+                            <div>
+                                <p><strong>Sarah Tran</strong> approved final budget for the Singapore flagship redesign.</p>
+                                <time>5 minutes ago</time>
+                            </div>
+                        </li>
+                        <li>
+                            <span class="avatar" aria-hidden="true">AM</span>
+                            <div>
+                                <p><strong>Akira Mori</strong> deployed trade-in diagnostics API to staging.</p>
+                                <time>27 minutes ago</time>
+                            </div>
+                        </li>
+                        <li>
+                            <span class="avatar" aria-hidden="true">OS</span>
+                            <div>
+                                <p><strong>Oliver Stone</strong> closed 14 AppleCare+ escalations.</p>
+                                <time>1 hour ago</time>
+                            </div>
+                        </li>
+                        <li>
+                            <span class="avatar" aria-hidden="true">LP</span>
+                            <div>
+                                <p><strong>Linh Pham</strong> shared in-store journey analytics with marketing.</p>
+                                <time>2 hours ago</time>
+                            </div>
+                        </li>
+                    </ul>
+                </article>
+
+                <article class="card goals-card">
+                    <div class="card-header">
+                        <h3>Quarterly goals</h3>
+                        <button class="icon-btn" aria-label="Edit goals"><i class="fa-regular fa-pen-to-square"></i></button>
+                    </div>
+                    <div class="goal">
+                        <div>
+                            <p class="goal-title">Reduce AppleCare+ churn to 2%</p>
+                            <p class="goal-caption">Current: 2.8%</p>
+                        </div>
+                        <span class="goal-progress">74%</span>
+                    </div>
+                    <div class="goal">
+                        <div>
+                            <p class="goal-title">Launch partner portal</p>
+                            <p class="goal-caption">Milestone: Beta testing</p>
+                        </div>
+                        <span class="goal-progress">61%</span>
+                    </div>
+                    <div class="goal">
+                        <div>
+                            <p class="goal-title">Increase retail NPS to 52</p>
+                            <p class="goal-caption">Current: 47</p>
+                        </div>
+                        <span class="goal-progress">48%</span>
+                    </div>
+                    <button class="secondary-btn"><i class="fa-solid fa-plus"></i>Add objective</button>
+                </article>
+            </section>
+
+            <footer class="footer">
+                <p>© 2024 Apple Inc. All rights reserved.</p>
+                <div class="footer-links">
+                    <a href="#">Privacy</a>
+                    <a href="#">Terms</a>
+                    <a href="#">Support</a>
                 </div>
-    
-                <div class="foot-count-3">
-                        <div class="copyright-foot">
-                            Copyright © 2023 Apple Inc. All rights reserved.
-                        </div>
-                        <div class="foot-3">
-                           Privacy Policy
-                        </div>
-                        <div class="foot-3">
-                            Terms of Use
-                        </div>
-                        <div class="foot-3">
-                            Sales Policy
-                        </div>
-                        <div class="foot-3">
-                            Legal
-                        </div>
-                        <div class="foot-3">
-                            Site Map
-                        </div>
-                        <div class="india">
-                            India
-                        </div>
-                </div>
-    
-    
-
-            </div>
-            
-
-        </footer> 
-
-
+            </footer>
+        </main>
     </div>
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/apple.css
+++ b/apple.css
@@ -1,577 +1,740 @@
+:root {
+    --bg: #f5f5f7;
+    --sidebar: #f0f0f5;
+    --sidebar-accent: #e8e8ed;
+    --card-bg: #ffffff;
+    --card-border: rgba(210, 210, 215, 0.6);
+    --primary: #0071e3;
+    --primary-dark: #005bb5;
+    --success: #34c759;
+    --warning: #ffcc00;
+    --danger: #ff3b30;
+    --info: #5ac8fa;
+    --text: #1d1d1f;
+    --muted: #6e6e73;
+    font-size: 16px;
+}
 
-
-*{
+* {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
 }
 
-/*nav bar*/
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', Arial, sans-serif;
+    background: linear-gradient(180deg, #f5f5f7 0%, #ffffff 60%);
+    min-height: 100vh;
+    color: var(--text);
+}
 
-.navcontent{
-    background-color: rgba(22, 22, 23, 0.9);
+.dashboard {
     display: flex;
-    justify-content: center;
-    align-items: center;
-    position: fixed; 
-    height: 2.75rem;
-    width: 100%;
-    z-index: 2;
+    min-height: 100vh;
 }
 
-.nav-belt{
-    padding-top: 30px;
-    gap: 2.55688rem;
-    color: white;
-    font-size: 12px;
-    font-weight: 100;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    width: 63%;
-    display: flex;
-    justify-content: space-between;
-}
-
-.nav-logo{
-    width: 14px;
-    height: 44px;
-    flex-shrink: 0;
-}
-
-.nav-search{
-    width: 14px;
-    height: 44px;
-    flex-shrink: 0;
-}
-
-.nav-shop{
-    width: 14px;
-    height: 44px;
-    flex-shrink: 0;
-}
-
-.main-info{
-    background-color: #1D1D1F;
-    width: 100%;
-    height: 2rem;
-    top: 2.75rem;
-    text-align: center;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative; 
-    z-index: 1;
-}
-
-.main-info-count{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-bottom: 3px;
-}
-
-.main-info p{
-    display: inline;
-    color: #FFF;
-    text-align: center;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.86819rem;
-    font-weight: lighter;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1.28688rem; 
-    letter-spacing: -0.02338rem;
-    padding-top: 5px;
-}
-
-.main-info a{
-    display: inline;
-    color: #06C;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.86819rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1.28688rem;
-    letter-spacing: -0.02338rem;
-}
-
-/*main section*/
-
-.main{
-    width: 100%;
-    background: #FBFBFD;
-    /* background-color: #1D1D1F; */
+.sidebar {
+    width: 260px;
+    background: linear-gradient(180deg, var(--sidebar) 0%, #ffffff 100%);
+    color: var(--text);
+    padding: 2rem 1.5rem 1.5rem;
     display: flex;
     flex-direction: column;
-    
-} 
+    gap: 2rem;
+    border-right: 1px solid var(--card-border);
+}
 
-.section{
-    height:37.5rem;
-    width: 100%;
-    background-image: url(download\ \(4\).jpeg);
-    background-position: center;
-    position: relative; 
+.brand {
     display: flex;
-    background-size: cover;
-    padding-bottom: 20px;
-    margin-bottom: 20px;
-    justify-content: center;
+    align-items: center;
+    font-weight: 600;
+    font-size: 1.2rem;
+    gap: 0.75rem;
 }
 
-.sec-cont{
-    text-align: center;
-    padding-top: 85px;
-} 
-
-.sec-cont-head h1{
-    font-size: 3.20606rem;
-    font-style: normal;
-    font-weight: bolder;
-    line-height: 3.75rem; 
-    letter-spacing: -0.0175rem;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-
+.brand i {
+    color: var(--primary);
+    background: rgba(0, 113, 227, 0.12);
+    padding: 0.5rem;
+    border-radius: 0.75rem;
 }
 
-.sec-cont-head p{
-    font-size: 1.49706rem;
-    font-style: normal;
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--muted);
+    text-decoration: none;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
     font-weight: 500;
-    line-height: 1.9375rem; 
-    letter-spacing: 0.007rem;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    margin: 12px;
+    transition: background 0.2s, color 0.2s, transform 0.2s;
 }
 
-.sec-cont-link{
-    display: flex;
-    justify-content: center;
-}
-
-.sec-cont-link .lm{
-    color: #2997FF;
+.nav-item i {
+    width: 1.25rem;
     text-align: center;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 1.14844rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1.8125rem; 
-    letter-spacing: 0.01444rem;
-    padding-right: 5px;
+    color: inherit;
 }
 
-.sec-cont-link .buy{
-    color: #2997FF;
-    text-align: center;
-    font-family: Inter;
-    font-size: 1.19969rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1.8125rem; 
-    letter-spacing: 0.01444rem;
-    padding-left: 25px;
+.nav-item:hover {
+    background: var(--sidebar-accent);
+    color: var(--text);
+    transform: translateX(4px);
 }
 
-#BGVideo {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+.nav-item.active {
+    background: var(--sidebar-accent);
+    color: var(--text);
+}
+
+.nav-item.active i {
+    color: var(--primary);
+}
+
+.sidebar-upgrade {
+    margin-top: auto;
+    padding: 1.25rem;
+    border-radius: 1rem;
+    background: rgba(232, 232, 237, 0.6);
+}
+
+.upgrade-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: var(--text);
+}
+
+.upgrade-body {
+    color: var(--muted);
+    font-size: 0.875rem;
+    line-height: 1.4;
+    margin-bottom: 1rem;
+}
+
+.upgrade-btn {
     width: 100%;
+    border: none;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    background: var(--primary);
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.2s;
+}
+
+.upgrade-btn:hover {
+    background: var(--primary-dark);
+    transform: translateY(-1px);
+}
+
+.main-content {
+    flex: 1;
+    padding: 2.5rem 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.85) 0%, rgba(245, 245, 247, 0.9) 100%);
+}
+
+.topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.search {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    background: var(--card-bg);
+    border-radius: 999px;
+    padding: 0.75rem 1rem;
+    gap: 0.75rem;
+    border: 1px solid var(--card-border);
+}
+
+.search i {
+    color: var(--muted);
+}
+
+.search input {
+    border: none;
+    outline: none;
+    width: 100%;
+    font-size: 0.95rem;
+    color: var(--text);
+    background: transparent;
+}
+
+.topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.icon-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    border: 1px solid var(--card-border);
+    background: rgba(255, 255, 255, 0.8);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    color: var(--muted);
+    transition: transform 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.icon-btn:hover {
+    transform: translateY(-2px);
+    color: var(--primary);
+    border-color: rgba(0, 113, 227, 0.35);
+}
+
+.profile {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+}
+
+.profile img {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
     object-fit: cover;
 }
 
-.section2 {
-    position: relative;
-    height: 600px; 
-    overflow: hidden; 
-    padding-top: 20px;
+.profile-name {
+    font-weight: 600;
 }
 
-.sec2-overlay {
+.profile-role {
+    color: var(--muted);
+    font-size: 0.8rem;
+}
+
+.welcome {
     display: flex;
-    justify-content: center;
-    position: absolute;
-    top: 90%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    text-align: center;
-    border-radius: 61.25rem;
-    background: #F5F5F7;
-    color: black;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.86819rem;
-    font-style: normal;
-    font-weight: 400;
-    text-align: center;
-    padding: 20px; 
-    z-index: 1;
-    width: 11.17875rem;
-    height: 2.175rem;
-    flex-shrink: 0;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+    background: linear-gradient(135deg, rgba(0, 113, 227, 0.08), rgba(232, 232, 237, 0.4));
+    padding: 1.5rem 2rem;
+    border-radius: 1.5rem;
+    border: 1px solid var(--card-border);
+    box-shadow: 0 18px 40px rgba(17, 17, 17, 0.04);
 }
 
-.sec2-overlay p{
-    color: #000;
-    text-align: center;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 1.05419rem;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 1.25rem; 
-    letter-spacing: -0.02338rem;
-    padding-right: 5px;
+.welcome h1 {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
 }
 
-.sec2-overlay svg{
-    padding-top: 4px;
+.product-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: linear-gradient(135deg, rgba(214, 198, 184, 0.35), rgba(245, 245, 247, 0.8));
+    color: var(--text);
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.8rem;
+    letter-spacing: 0.02em;
+    margin-bottom: 0.75rem;
 }
 
-.section3{
-    background-image: url(Applemaim.png);
-    height:37.5rem;
-    width: 100%;
-    background-position: center;
-    position: relative; 
+.product-pill::before {
+    content: '';
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #c09f7a, #b58d68);
+    box-shadow: 0 0 0 2px rgba(214, 198, 184, 0.5);
+}
+
+.welcome p {
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.primary-btn,
+.secondary-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: none;
+    border-radius: 0.9rem;
+    padding: 0.85rem 1.4rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+}
+
+.primary-btn {
+    background: linear-gradient(135deg, #0a84ff, #0071e3);
+    color: #fff;
+    box-shadow: 0 15px 30px rgba(10, 132, 255, 0.35);
+}
+
+.primary-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 40px rgba(0, 113, 227, 0.45);
+}
+
+.secondary-btn {
+    background: rgba(0, 113, 227, 0.1);
+    color: var(--primary);
+}
+
+.secondary-btn:hover {
+    transform: translateY(-2px);
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1.5rem;
+}
+
+.stat-card {
+    background: rgba(255, 255, 255, 0.85);
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+    border: 1px solid var(--card-border);
     display: flex;
     flex-direction: column;
-    background-size: cover;
-    padding-top: 20px;
-    margin-top: 20px;
+    gap: 1.25rem;
+    box-shadow: 0 16px 32px rgba(17, 17, 17, 0.05);
+}
+
+.stat-header {
+    display: flex;
+    justify-content: space-between;
     align-items: center;
+}
+
+.stat-title {
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.stat-badge {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.stat-badge.positive {
+    background: rgba(52, 199, 89, 0.16);
+    color: var(--success);
+}
+
+.stat-badge.neutral {
+    background: rgba(0, 113, 227, 0.14);
+    color: var(--primary);
+}
+
+.stat-badge.negative {
+    background: rgba(255, 59, 48, 0.14);
+    color: var(--danger);
+}
+
+.stat-caption {
+    color: var(--muted);
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
+.sparkline {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    align-items: end;
+    gap: 0.4rem;
+    height: 60px;
+}
+
+.sparkline div {
+    background: linear-gradient(180deg, rgba(0, 113, 227, 0.12), rgba(0, 113, 227, 0.6));
+    border-radius: 0.75rem;
+}
+
+.progress {
+    width: 100%;
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(232, 232, 237, 0.6);
+    overflow: hidden;
+}
+
+.progress.small {
+    height: 6px;
+}
+
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #0a84ff, #0071e3);
+    border-radius: inherit;
+}
+
+.progress-bar.warning {
+    background: linear-gradient(90deg, #ffcc00, #ffb800);
+}
+
+.progress-bar.info {
+    background: linear-gradient(90deg, #5ac8fa, #32ade6);
+}
+
+.stat-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 0.5rem;
+}
+
+.dot.success {
+    background: var(--success);
+}
+
+.dot.warning {
+    background: var(--warning);
+}
+
+.dot.danger {
+    background: var(--danger);
+}
+
+.dot.info {
+    background: var(--info);
+}
+
+.subscription-chart {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+    height: 70px;
+}
+
+.subscription-chart .bar {
+    flex: 1;
+    border-radius: 0.75rem;
+    background: linear-gradient(180deg, rgba(0, 113, 227, 0.18), rgba(0, 113, 227, 0.65));
+}
+
+.grid-two {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+}
+
+.card {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 1.5rem;
+    border: 1px solid var(--card-border);
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    box-shadow: 0 20px 40px rgba(17, 17, 17, 0.05);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.card-header h3 {
+    font-size: 1.1rem;
+}
+
+.card-header a {
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.chart-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.chart-legend p {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--muted);
+    font-weight: 500;
+    margin-bottom: 0.6rem;
+}
+
+.chart-pie {
+    position: relative;
+    width: 160px;
+    height: 160px;
+    margin: 0 auto;
+}
+
+.pie {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: conic-gradient(
+        rgba(0, 113, 227, 0.85) 0 220deg,
+        rgba(90, 200, 250, 0.85) 220deg 300deg,
+        rgba(255, 204, 0, 0.85) 300deg 340deg,
+        rgba(255, 59, 48, 0.85) 340deg 360deg
+    );
+    box-shadow: inset 0 0 30px rgba(29, 29, 31, 0.08);
+}
+
+.pie-center {
+    position: absolute;
+    inset: 50% auto auto 50%;
+    transform: translate(-50%, -50%);
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    background: var(--card-bg);
+    display: grid;
+    place-items: center;
+    text-align: center;
+    gap: 0.25rem;
+    font-weight: 600;
+    color: var(--text);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+}
+
+.pie-center small {
+    font-size: 0.7rem;
+    color: var(--muted);
+    font-weight: 500;
+}
+
+.card-footer {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+thead th {
+    text-align: left;
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 0.85rem;
     padding-bottom: 0.75rem;
 }
-.sec-cont3{
-    text-align: center;
-    padding-top: 35px;
-}
 
-.sec3-h {
-    color: #F5F5F7;
-    text-align: center;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 3.20606rem;
-    font-style: normal;
-    font-weight: 600;
-    line-height: 3.75rem;
-    letter-spacing: -0.0175rem;
-}
-
-.sec3-p{
-    color: #F5F5F7;
-    text-align: center;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 1.49706rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1.9375rem; 
-    letter-spacing: 0.007rem;
-}
-
-
-.section4 {
-    width: 100%;
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 15px;
-    padding: 15px;
-}
-
-.sec-cont-shop{
-    display: flex;
-    text-align: center ;
-    justify-content: center;
-    align-items: center;
-
-}
-
-.box {
-    background-size: cover;
-    background-position: center;
-    width: 100%;
-    height: 500px;
-    flex-shrink: 0;
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    background-color: lightgray; 
-}
-
-.box-cont {
-    padding-top: 20px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-}
-
-.box-cont h1 {
-    color: #1D1D1F;
-    text-align: center;
-    font-size: 2.26563rem;
-    font-style: normal;
-    font-weight: 600;
-    line-height: 2.75rem; 
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    
-}
-
-.box-cont p{
-    color: #1D1D1F;
-    text-align: center;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 1.15869rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1.625rem;
-    letter-spacing: 0.021rem;
-    margin: 5px;
-}
-
-.box-cont img{
-    padding-bottom: 5px;
-}
-.boxh1{
-    color: #F5F5F7;
-    text-align: center;
-    font-size: 2.26563rem;
-    font-style: normal;
-    font-weight: 600;
-    line-height: 2.75rem; 
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-}
-
-.boxp{
-    color: #F5F5F7;
-    text-align: center;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 1.15869rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1.625rem;
-    letter-spacing: 0.021rem;
-}
-
-/*footer*/
-
-.footer{
-    background-color: #F5F5F7;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding-top: 10px;
-    padding: 0rem 28rem;
-    justify-content: center;
-    flex-shrink: 0;
-}
-
-.footer-all{
-    width: 64rem;
-    height: 49.21875rem;
-    flex-shrink: 0;
-}
-
-.foot-cont-1{
-    text-align: center;
-    display: inline-flex;
-    padding: 1.125rem 0.20625rem 1.4125rem 0rem;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.72438rem;
-    border-bottom: 1px solid #D2D2D7;
-}
-
-.p1,.p2,.p3,.p4{
-    padding-bottom: 6px;
-    color: #6E6E73;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.73831rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1rem; 
-    letter-spacing: -0.0075rem;  
-    text-align: start;
-}
-
-.p1 a{
-    color: #424245;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.73831rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1rem;
-    text-decoration-line: underline;
-}
-
-.p2 a{
-    color: #424245;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.73831rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1rem;
-    text-decoration-line: underline;
-}
-
-
-.foot-count-2{
-    height: 400px;
-    display: flex;
-    justify-content: space-evenly;
-    border-bottom: 2px solid #D2D2D7;
-    padding-bottom: 30px;
-    padding-top: 15px;
-}
-
-ul{
-    margin-top: 30px;
-}
-
-ul a{
-    display: block;
-    margin-top: 10px;
-    color: #424245;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.75rem;
-    font-style: normal;
+tbody tr td {
+    padding: 0.75rem 0;
+    border-top: 1px solid var(--card-border);
     font-weight: 500;
-    line-height: 1rem; 
 }
 
-ul p{
-    font-weight: bolder;
-    color: #1D1D1F;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
+.status {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
     font-size: 0.75rem;
-    font-style: normal;
-    line-height: 1rem;
-    letter-spacing: -0.0075rem;
-    padding-top: 15px;
+    font-weight: 600;
 }
 
-.foot-count-3 {
-    width: 64rem;
-    display: flex;
-    justify-content: space-evenly;
-    align-items: end;
-    top: 20%;
-    padding-top: 5px;
+.status.success {
+    background: rgba(52, 199, 89, 0.18);
+    color: var(--success);
 }
 
-.copyright-foot{
+.status.warning {
+    background: rgba(255, 204, 0, 0.2);
+    color: var(--warning);
+}
+
+.status.info {
+    background: rgba(90, 200, 250, 0.18);
+    color: var(--info);
+}
+
+.activity-list {
+    list-style: none;
     display: flex;
-    width: 17.02813rem;
-    height: 1rem;
     flex-direction: column;
-    justify-content: start;
-    flex-shrink: 0;
-    color: #6E6E73;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.75rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1rem; 
-    padding-right: 12px;
+    gap: 1.25rem;
 }
 
-.foot-3{
-    display: inline-flex;
-    height: 1rem;
-    padding-right: 0.675rem;
-    padding-left: 5px;
+.activity-list li {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.activity-list p {
+    line-height: 1.5;
+}
+
+.activity-list time {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.avatar {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: rgba(0, 113, 227, 0.15);
+    color: var(--primary);
+    font-weight: 600;
+    display: grid;
+    place-items: center;
+}
+
+.goal {
+    display: flex;
+    justify-content: space-between;
     align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    color: #424245;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.73831rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1rem; 
-    border-right: 1px solid #86868B;
+    padding: 1rem;
+    border-radius: 1rem;
+    background: rgba(232, 232, 237, 0.5);
+    color: var(--text);
+    gap: 1rem;
 }
 
-.india{
-    padding-left: 280px;
+.goal + .goal {
+    margin-top: 0.75rem;
+}
+
+.goal-title {
+    font-weight: 600;
+}
+
+.goal-caption {
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-top: 0.35rem;
+}
+
+.goal-progress {
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.footer {
     display: flex;
-    width: 1.71063rem;
-    height: 0.875rem;
-    flex-direction: column;
-    justify-content: center;
-    flex-shrink: 0;
-    color: #424245;
-    font-family: 'Bebas Neue', sans-serif;
-    font-family: 'Inter', sans-serif;
-    font-family: 'Open Sans', sans-serif;
-    font-family: 'Roboto', sans-serif;
-    font-size: 0.75rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1rem; 
-
+    justify-content: space-between;
+    align-items: center;
+    color: var(--muted);
+    font-size: 0.85rem;
 }
 
+.footer-links {
+    display: flex;
+    gap: 1rem;
+}
 
+.footer-links a {
+    color: var(--muted);
+    text-decoration: none;
+    transition: color 0.2s;
+}
 
+.footer-links a:hover {
+    color: var(--primary);
+}
 
+@media (max-width: 1200px) {
+    .stats-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 
+    .grid-two {
+        grid-template-columns: 1fr;
+    }
+}
 
+@media (max-width: 900px) {
+    .dashboard {
+        flex-direction: column;
+    }
 
+    .sidebar {
+        width: 100%;
+        flex-direction: row;
+        align-items: center;
+        padding: 1.5rem;
+        gap: 1.5rem;
+        overflow-x: auto;
+    }
 
+    .sidebar-nav {
+        flex-direction: row;
+        gap: 1rem;
+    }
 
+    .sidebar-upgrade {
+        min-width: 220px;
+    }
 
+    .main-content {
+        padding: 2rem 1.5rem;
+    }
 
+    .topbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .welcome {
+        flex-direction: column;
+    }
+}
+
+@media (max-width: 640px) {
+    .stats-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        display: none;
+    }
+
+    .main-content {
+        padding: 1.5rem 1rem;
+    }
+
+    .welcome {
+        padding: 1.25rem;
+    }
+
+    .card {
+        padding: 1.25rem;
+    }
+}


### PR DESCRIPTION
## Summary
- refresh the admin dashboard copy and navigation to reflect Apple operations terminology
- update the hero, metrics, and widgets to feature product-focused language and highlights
- overhaul the color system to a minimal Apple palette with refined gradients and accents

## Testing
- not run (static HTML/CSS project)


------
https://chatgpt.com/codex/tasks/task_e_68d5a2c130b4832986ae702281add0b6