### PR TITLE
Soften sidebar navigation elevation

### DIFF
--- a/Apple.html
+++ b/Apple.html
@@ -18,12 +18,161 @@
                 <span>Apple Operations</span>
             </div>
             <nav class="sidebar-nav">
-                <a href="#" class="nav-item active"><i class="fa-solid fa-gauge"></i>Overview</a>
-                <a href="#" class="nav-item"><i class="fa-solid fa-store"></i>Retail performance</a>
-                <a href="#" class="nav-item"><i class="fa-solid fa-box"></i>Supply chain</a>
-                <a href="#" class="nav-item"><i class="fa-solid fa-mobile-screen"></i>Devices</a>
-                <a href="#" class="nav-item"><i class="fa-solid fa-headset"></i>Customer care</a>
-                <a href="#" class="nav-item"><i class="fa-solid fa-gear"></i>Settings</a>
+                <ul class="sidebar-menu">
+                    <li class="menu-item">
+                        <a href="#" class="nav-link active">
+                            <span class="nav-icon">
+                                <i class="fa-solid fa-gauge"></i>
+                            </span>
+                            <div class="nav-text">
+                                <span class="nav-label">Dashboard</span>
+                                <span class="nav-translation">Thống kê</span>
+                            </div>
+                        </a>
+                    </li>
+                    <li class="menu-item dropdown open">
+                        <button class="nav-link dropdown-toggle" type="button" aria-expanded="true" aria-controls="submenu-links">
+                            <span class="nav-icon">
+                                <i class="fa-solid fa-link"></i>
+                            </span>
+                            <div class="nav-text">
+                                <span class="nav-label">Manage Links</span>
+                                <span class="nav-translation">Quản lý liên kết</span>
+                            </div>
+                            <span class="nav-caret"><i class="fa-solid fa-chevron-down"></i></span>
+                        </button>
+                        <ul class="submenu" id="submenu-links">
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-layer-group"></i></span>
+                                    <span class="submenu-label">All Links</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-eye-slash"></i></span>
+                                    <span class="submenu-label">Hidden Links</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-circle-pause"></i></span>
+                                    <span class="submenu-label">Inactive Links</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="menu-item dropdown">
+                        <button class="nav-link dropdown-toggle" type="button" aria-expanded="false" aria-controls="submenu-users">
+                            <span class="nav-icon">
+                                <i class="fa-solid fa-users"></i>
+                            </span>
+                            <div class="nav-text">
+                                <span class="nav-label">Users</span>
+                                <span class="nav-translation">Người dùng</span>
+                            </div>
+                            <span class="nav-caret"><i class="fa-solid fa-chevron-down"></i></span>
+                        </button>
+                        <ul class="submenu" id="submenu-users">
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-rectangle-list"></i></span>
+                                    <span class="submenu-label">List</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-user-plus"></i></span>
+                                    <span class="submenu-label">Add</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-user-group"></i></span>
+                                    <span class="submenu-label">Referrals</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-file-export"></i></span>
+                                    <span class="submenu-label">Export</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="menu-item">
+                        <a href="#" class="nav-link">
+                            <span class="nav-icon">
+                                <i class="fa-solid fa-chart-line"></i>
+                            </span>
+                            <div class="nav-text">
+                                <span class="nav-label">Reports</span>
+                                <span class="nav-translation">Báo cáo</span>
+                            </div>
+                        </a>
+                    </li>
+                    <li class="menu-item dropdown">
+                        <button class="nav-link dropdown-toggle" type="button" aria-expanded="false" aria-controls="submenu-settings">
+                            <span class="nav-icon">
+                                <i class="fa-solid fa-gear"></i>
+                            </span>
+                            <div class="nav-text">
+                                <span class="nav-label">Settings</span>
+                                <span class="nav-translation">Cài đặt</span>
+                            </div>
+                            <span class="nav-caret"><i class="fa-solid fa-chevron-down"></i></span>
+                        </button>
+                        <ul class="submenu" id="submenu-settings">
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-sliders"></i></span>
+                                    <span class="submenu-label">Settings</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-rectangle-ad"></i></span>
+                                    <span class="submenu-label">Ads</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-money-check-dollar"></i></span>
+                                    <span class="submenu-label">Withdraw</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-envelope"></i></span>
+                                    <span class="submenu-label">Email</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-fingerprint"></i></span>
+                                    <span class="submenu-label">Social Login</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="submenu-link">
+                                    <span class="submenu-icon"><i class="fa-solid fa-credit-card"></i></span>
+                                    <span class="submenu-label">Payment Methods</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="menu-item logout">
+                        <a href="#" class="nav-link">
+                            <span class="nav-icon">
+                                <i class="fa-solid fa-right-from-bracket"></i>
+                            </span>
+                            <div class="nav-text">
+                                <span class="nav-label">Logout</span>
+                                <span class="nav-translation">Đăng xuất</span>
+                            </div>
+                        </a>
+                    </li>
+                </ul>
             </nav>
             <div class="sidebar-upgrade">
                 <p class="upgrade-title">Need more insight?</p>
@@ -281,5 +430,26 @@
             </footer>
         </main>
     </div>
+    <script>
+        const dropdownToggles = document.querySelectorAll('.dropdown-toggle');
+        dropdownToggles.forEach((toggle) => {
+            const parent = toggle.closest('.dropdown');
+            const submenu = parent.querySelector('.submenu');
+            const isInitiallyOpen = parent.classList.contains('open');
+
+            toggle.setAttribute('aria-expanded', String(isInitiallyOpen));
+            if (submenu) {
+                submenu.setAttribute('aria-hidden', String(!isInitiallyOpen));
+            }
+
+            toggle.addEventListener('click', () => {
+                const isOpen = parent.classList.toggle('open');
+                toggle.setAttribute('aria-expanded', String(isOpen));
+                if (submenu) {
+                    submenu.setAttribute('aria-hidden', String(!isOpen));
+                }
+            });
+        });
+    </script>
 </body>
 </html>

--- a/apple.css
+++ b/apple.css
@@ -31,17 +31,58 @@ body {
 .dashboard {
     display: flex;
     min-height: 100vh;
+    padding: clamp(2rem, 4vw, 3rem);
+    gap: clamp(1.75rem, 3vw, 2.75rem);
+    align-items: flex-start;
 }
 
 .sidebar {
     width: 260px;
-    background: linear-gradient(180deg, var(--sidebar) 0%, #ffffff 100%);
+    background: linear-gradient(180deg,
+            rgba(240, 240, 245, 0.45) 0%,
+            rgba(224, 230, 248, 0.35) 48%,
+            rgba(214, 220, 240, 0.26) 100%);
     color: var(--text);
-    padding: 2rem 1.5rem 1.5rem;
+    padding: 2rem 1.75rem 1.75rem;
     display: flex;
     flex-direction: column;
     gap: 2rem;
-    border-right: 1px solid var(--card-border);
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    border-radius: 28px;
+    backdrop-filter: blur(12px);
+    box-shadow: 0 28px 65px rgba(15, 23, 42, 0.12), 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.sidebar::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border: 1px solid rgba(255, 255, 255, 0.38);
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.sidebar::after {
+    content: "";
+    position: absolute;
+    inset: -15% -20% -25% -10%;
+    background: linear-gradient(135deg,
+            rgba(255, 255, 255, 0.45) 0%,
+            rgba(255, 255, 255, 0.18) 45%,
+            rgba(255, 255, 255, 0) 70%),
+        radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0.12) 42%, rgba(255, 255, 255, 0) 65%);
+    opacity: 0.75;
+    mix-blend-mode: screen;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.sidebar > * {
+    position: relative;
+    z-index: 3;
 }
 
 .brand {
@@ -62,40 +103,302 @@ body {
 .sidebar-nav {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
 }
 
-.nav-item {
+.sidebar-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.menu-item {
+    position: relative;
+}
+
+.nav-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    line-height: 1.2;
+    position: relative;
+    z-index: 1;
+}
+
+.nav-label {
+    font-weight: 600;
+    color: inherit;
+    font-size: 0.95rem;
+}
+
+.nav-translation {
+    font-size: 0.75rem;
+    color: var(--muted);
+    opacity: 0.78;
+    letter-spacing: 0.02em;
+}
+
+.nav-link {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.85rem;
+    width: 100%;
     color: var(--muted);
     text-decoration: none;
-    padding: 0.75rem 1rem;
-    border-radius: 0.75rem;
+    padding: 0.65rem 1rem;
+    border-radius: 0.9rem;
     font-weight: 500;
-    transition: background 0.2s, color 0.2s, transform 0.2s;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.02) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32), 0 9px 20px rgba(15, 23, 42, 0.06);
+    position: relative;
+    overflow: hidden;
+    transition: background 0.35s ease, color 0.25s ease, border-color 0.35s ease, box-shadow 0.35s ease, transform 0.25s ease;
 }
 
-.nav-item i {
-    width: 1.25rem;
-    text-align: center;
+.nav-link:focus-visible {
+    outline: 2px solid rgba(52, 120, 246, 0.38);
+    outline-offset: 2px;
+}
+
+.nav-link::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.42) 0%, rgba(255, 255, 255, 0) 60%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.35s ease;
+}
+
+.nav-link > *:not(.nav-caret) {
+    position: relative;
+    z-index: 1;
+}
+
+.dropdown-toggle {
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+}
+
+.dropdown-toggle:focus-visible {
+    outline: 2px solid rgba(52, 120, 246, 0.35);
+    outline-offset: 2px;
+}
+
+.nav-icon {
+    width: 34px;
+    height: 34px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0.06) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.26);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 6px 12px rgba(15, 23, 42, 0.1);
     color: inherit;
+    transition: background 0.35s ease, color 0.3s ease, border-color 0.35s ease, box-shadow 0.35s ease;
 }
 
-.nav-item:hover {
-    background: var(--sidebar-accent);
+.nav-icon i {
+    font-size: 1rem;
+}
+
+.nav-caret {
+    margin-left: auto;
+    color: inherit;
+    display: flex;
+    align-items: center;
+    transition: transform 0.3s ease;
+    position: relative;
+    z-index: 1;
+}
+
+.dropdown.open .nav-caret {
+    transform: rotate(0deg);
+}
+
+.dropdown:not(.open) .nav-caret {
+    transform: rotate(-90deg);
+}
+
+.submenu {
+    list-style: none;
+    display: grid;
+    gap: 0.35rem;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-4px);
+    visibility: hidden;
+    transition: max-height 0.3s ease, opacity 0.2s ease, transform 0.2s ease;
+    position: relative;
+    margin-left: 0;
+}
+
+.dropdown.open .submenu {
+    padding: 0.55rem 0 0.65rem;
+    max-height: 600px;
+    opacity: 1;
+    transform: translateY(0);
+    visibility: visible;
+}
+
+.submenu::before {
+    content: "";
+    position: absolute;
+    left: 2.35rem;
+    top: 0.85rem;
+    bottom: 0.85rem;
+    width: 1px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.38) 0%, rgba(255, 255, 255, 0.06) 100%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.dropdown.open .submenu::before {
+    opacity: 1;
+}
+
+.submenu-link {
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-decoration: none;
+    padding: 0.4rem 0.8rem 0.4rem 0.6rem;
+    border-radius: 0.7rem;
+    transition: background 0.25s ease, color 0.2s ease, transform 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    position: relative;
+    margin-left: 2.9rem;
+    isolation: isolate;
+}
+
+.submenu-link:focus-visible {
+    outline: 2px solid rgba(52, 120, 246, 0.35);
+    outline-offset: 2px;
+}
+
+.submenu-icon {
+    width: 1.65rem;
+    height: 1.65rem;
+    border-radius: 0.9rem;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.62) 0%, rgba(255, 255, 255, 0.18) 100%);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72), 0 5px 12px rgba(15, 23, 42, 0.12);
+    display: grid;
+    place-items: center;
+    color: rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    flex-shrink: 0;
+    transition: background 0.25s ease, color 0.2s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.submenu-icon i {
+    font-size: 0.75rem;
+}
+
+.submenu-link:hover .submenu-icon,
+.submenu-link:focus-visible .submenu-icon {
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.86) 0%, rgba(255, 255, 255, 0.32) 100%);
+    border-color: rgba(255, 255, 255, 0.66);
+    color: var(--primary);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 7px 16px rgba(15, 23, 42, 0.16);
+}
+
+.submenu-link:hover {
+    background: rgba(232, 232, 237, 0.38);
     color: var(--text);
+    transform: translateX(4px);
+    box-shadow: 0 8px 14px rgba(15, 23, 42, 0.07);
+}
+
+.submenu-label {
+    flex: 1;
+    white-space: nowrap;
+}
+
+.nav-link:hover {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.16) 100%);
+    color: var(--text);
+    border-color: rgba(255, 255, 255, 0.36);
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
     transform: translateX(4px);
 }
 
-.nav-item.active {
-    background: var(--sidebar-accent);
+.nav-link:hover::after {
+    opacity: 1;
+}
+
+.nav-link.active,
+.dropdown.open > .nav-link {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.68) 0%, rgba(255, 255, 255, 0.22) 100%);
+    color: var(--text);
+    border-color: rgba(255, 255, 255, 0.42);
+    box-shadow: 0 20px 36px rgba(15, 23, 42, 0.13);
+}
+
+.nav-link.active i {
+    color: var(--primary);
+}
+
+.dropdown.open > .nav-link i {
     color: var(--text);
 }
 
-.nav-item.active i {
+.nav-link.active::after,
+.dropdown.open > .nav-link::after {
+    opacity: 1;
+}
+
+.nav-link:hover .nav-icon,
+.nav-link.active .nav-icon,
+.dropdown.open > .nav-link .nav-icon {
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.26) 100%);
+    border-color: rgba(255, 255, 255, 0.56);
     color: var(--primary);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78), 0 9px 18px rgba(15, 23, 42, 0.15);
+}
+
+.nav-link:hover .nav-translation,
+.nav-link.active .nav-translation,
+.dropdown.open > .nav-link .nav-translation {
+    color: var(--text);
+    opacity: 0.7;
+}
+
+.menu-item.logout {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.menu-item.logout .nav-link {
+    color: #c2524f;
+    background: linear-gradient(135deg, rgba(255, 235, 235, 0.3) 0%, rgba(255, 219, 219, 0.1) 100%);
+    border-color: rgba(255, 212, 212, 0.32);
+}
+
+.menu-item.logout .nav-icon {
+    background: linear-gradient(135deg, rgba(255, 241, 241, 0.72) 0%, rgba(255, 220, 220, 0.3) 100%);
+    border-color: rgba(255, 212, 212, 0.48);
+    color: #c2524f;
+}
+
+.menu-item.logout .nav-link:hover {
+    color: #912727;
+    border-color: rgba(255, 198, 198, 0.52);
+    box-shadow: 0 18px 32px rgba(145, 39, 39, 0.18);
+}
+
+.menu-item.logout .nav-link:hover .nav-icon {
+    color: #912727;
 }
 
 .sidebar-upgrade {
@@ -141,7 +444,31 @@ body {
     display: flex;
     flex-direction: column;
     gap: 2rem;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.85) 0%, rgba(245, 245, 247, 0.9) 100%);
+    position: relative;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(245, 245, 247, 0.88) 55%, rgba(241, 241, 244, 0.92) 100%);
+    border-radius: 34px;
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+    overflow: hidden;
+    isolation: isolate;
+}
+
+.main-content::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 45%),
+        radial-gradient(circle at 20% 15%, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0) 55%),
+        radial-gradient(circle at 85% 20%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0) 50%);
+    opacity: 0.7;
+    mix-blend-mode: screen;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.main-content > * {
+    position: relative;
+    z-index: 2;
 }
 
 .topbar {
@@ -264,6 +591,33 @@ body {
     border-radius: 50%;
     background: linear-gradient(135deg, #c09f7a, #b58d68);
     box-shadow: 0 0 0 2px rgba(214, 198, 184, 0.5);
+}
+
+@media (max-width: 1200px) {
+    .dashboard {
+        padding: clamp(1.5rem, 5vw, 2rem);
+        gap: clamp(1.25rem, 4vw, 2rem);
+    }
+
+    .main-content {
+        padding: 2rem clamp(1.75rem, 4vw, 2.5rem);
+    }
+}
+
+@media (max-width: 900px) {
+    .dashboard {
+        flex-direction: column;
+        padding: clamp(1.25rem, 6vw, 1.75rem);
+    }
+
+    .sidebar {
+        width: 100%;
+        border-radius: 24px;
+    }
+
+    .main-content {
+        padding: 2rem clamp(1.5rem, 6vw, 2rem);
+    }
 }
 
 .welcome p {


### PR DESCRIPTION
## Summary
- lighten the sidebar nav pill backgrounds, borders, and shadows so each link feels less bulky while keeping the glassmorphism vibe
- slim down icon badges and submenu spacing for a tidier, lower-elevation dropdown presentation
- soften the logout styling to match the calmer surface treatments across the menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60e852f008329a473c46e9974957d