### PR TITLE
Align admin cert theme with TailAdmin palette

### DIFF
--- a/admin-dashboard-cert/index.html
+++ b/admin-dashboard-cert/index.html
@@ -1,0 +1,588 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Apple Connect Certificate Admin</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-theme="light">
+    <div class="app">
+      <aside class="sidebar" aria-label="Sidebar navigation" aria-hidden="false">
+        <div class="sidebar__brand">
+          <button class="sidebar__menu-toggle" type="button" aria-label="Close menu">
+            <i class="fa-solid fa-xmark"></i>
+          </button>
+          <div class="sidebar__logo-group">
+            <span class="sidebar__logo">CertifyOS</span>
+            <span class="sidebar__badge">Apple Connect</span>
+          </div>
+        </div>
+        <div class="sidebar__scroll">
+          <nav class="sidebar__nav" aria-label="Primary">
+            <p class="sidebar__section">Overview</p>
+            <a class="sidebar__link sidebar__link--active" href="#">
+              <span class="sidebar__icon" aria-hidden="true">
+                <i class="fa-solid fa-chart-line"></i>
+              </span>
+              Executive Analytics
+            </a>
+            <div class="sidebar__group sidebar__group--open" data-dropdown>
+              <button
+                class="sidebar__link sidebar__link--dropdown"
+                type="button"
+                aria-expanded="true"
+              >
+                <span class="sidebar__icon" aria-hidden="true">
+                  <i class="fa-solid fa-certificate"></i>
+                </span>
+                Certificate Sales
+                <span class="sidebar__chevron" aria-hidden="true">
+                  <i class="fa-solid fa-chevron-down"></i>
+                </span>
+              </button>
+              <div class="sidebar__submenu">
+                <a class="sidebar__sublink sidebar__sublink--active" href="#">Sales Performance</a>
+                <a class="sidebar__sublink" href="#">Product Catalog</a>
+                <a class="sidebar__sublink" href="#">Order Pipelines</a>
+                <a class="sidebar__sublink" href="#">Renewal Cohorts</a>
+              </div>
+            </div>
+            <div class="sidebar__group" data-dropdown>
+              <button
+                class="sidebar__link sidebar__link--dropdown"
+                type="button"
+                aria-expanded="false"
+              >
+                <span class="sidebar__icon" aria-hidden="true">
+                  <i class="fa-brands fa-apple"></i>
+                </span>
+                Apple Connect Ops
+                <span class="sidebar__chevron" aria-hidden="true">
+                  <i class="fa-solid fa-chevron-down"></i>
+                </span>
+              </button>
+              <div class="sidebar__submenu">
+                <a class="sidebar__sublink" href="#">API Status</a>
+                <a class="sidebar__sublink" href="#">Sync Activity</a>
+                <a class="sidebar__sublink" href="#">Webhook Events</a>
+                <a class="sidebar__sublink" href="#">Access Control</a>
+              </div>
+            </div>
+            <div class="sidebar__group" data-dropdown>
+              <button
+                class="sidebar__link sidebar__link--dropdown"
+                type="button"
+                aria-expanded="false"
+              >
+                <span class="sidebar__icon" aria-hidden="true">
+                  <i class="fa-solid fa-bullhorn"></i>
+                </span>
+                Growth &amp; Marketing
+                <span class="sidebar__chevron" aria-hidden="true">
+                  <i class="fa-solid fa-chevron-down"></i>
+                </span>
+              </button>
+              <div class="sidebar__submenu">
+                <a class="sidebar__sublink" href="#">Campaign Planner</a>
+                <a class="sidebar__sublink" href="#">Partner Channels</a>
+                <a class="sidebar__sublink" href="#">Creative Library</a>
+              </div>
+            </div>
+            <a class="sidebar__link" href="#">
+              <span class="sidebar__icon" aria-hidden="true">
+                <i class="fa-solid fa-gear"></i>
+              </span>
+              Platform Settings
+            </a>
+          </nav>
+          <div class="sidebar__upgrade" aria-label="Upgrade promotion">
+            <h3>Realtime Apple Connect</h3>
+            <p>
+              Upgrade to live sync for instant device registration, automated
+              certificate renewal, and proactive compliance alerts.
+            </p>
+            <button type="button">Enable Live Sync</button>
+          </div>
+        </div>
+      </aside>
+
+      <div class="workspace">
+        <header class="topbar">
+          <button class="topbar__menu" type="button" aria-label="Toggle sidebar">
+            <i class="fa-solid fa-bars"></i>
+          </button>
+          <form class="search" role="search">
+            <label for="search" class="visually-hidden">Search</label>
+            <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+            <input id="search" type="search" placeholder="Search dashboards, orders, or teams" />
+          </form>
+          <div class="topbar__actions">
+            <button class="topbar__button" type="button" aria-label="View notifications">
+              <i class="fa-regular fa-bell"></i>
+            </button>
+            <button class="topbar__button" type="button" aria-label="Open support chat">
+              <i class="fa-regular fa-life-ring"></i>
+            </button>
+            <button
+              class="topbar__button"
+              type="button"
+              data-theme-toggle
+              aria-label="Switch to dark mode"
+              aria-pressed="false"
+            >
+              <i class="fa-solid fa-moon" aria-hidden="true"></i>
+            </button>
+            <div class="avatar" role="button" tabindex="0" aria-haspopup="true" aria-label="Open profile menu">
+              <img src="https://i.pravatar.cc/100?img=47" alt="Operations lead" />
+              <span>
+                <strong>Mai Nguyen</strong>
+                <small>Operations Lead</small>
+              </span>
+              <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
+            </div>
+          </div>
+        </header>
+
+        <main class="main">
+          <section class="main__header">
+            <div>
+              <h1>Apple Certificate Analytics</h1>
+              <p>Monitor commerce performance, developer adoption, and API health.</p>
+            </div>
+            <button class="primary" type="button">
+              <i class="fa-solid fa-download"></i>
+              Export Insights
+            </button>
+          </section>
+
+          <section class="stats">
+            <article class="stat-card">
+              <div class="stat-card__icon">
+                <i class="fa-solid fa-receipt"></i>
+              </div>
+              <div class="stat-card__meta">
+                <h2>$218K</h2>
+                <p>Certificate revenue</p>
+                <span class="stat-card__delta stat-card__delta--up">
+                  <i class="fa-solid fa-arrow-trend-up"></i>
+                  12.4% vs last week
+                </span>
+              </div>
+            </article>
+            <article class="stat-card">
+              <div class="stat-card__icon">
+                <i class="fa-solid fa-ticket"></i>
+              </div>
+              <div class="stat-card__meta">
+                <h2>1,842</h2>
+                <p>Certificates activated</p>
+                <span class="stat-card__delta stat-card__delta--up">
+                  <i class="fa-solid fa-arrow-trend-up"></i>
+                  6.8% conversion uplift
+                </span>
+              </div>
+            </article>
+            <article class="stat-card">
+              <div class="stat-card__icon">
+                <i class="fa-solid fa-people-group"></i>
+              </div>
+              <div class="stat-card__meta">
+                <h2>928</h2>
+                <p>Team seats provisioned</p>
+                <span class="stat-card__delta stat-card__delta--down">
+                  <i class="fa-solid fa-arrow-trend-down"></i>
+                  1.9% churn rate
+                </span>
+              </div>
+            </article>
+            <article class="stat-card">
+              <div class="stat-card__icon">
+                <i class="fa-solid fa-server"></i>
+              </div>
+              <div class="stat-card__meta">
+                <h2>99.98%</h2>
+                <p>Apple Connect uptime</p>
+                <span class="stat-card__delta stat-card__delta--up">
+                  <i class="fa-solid fa-arrow-trend-up"></i>
+                  +54 resolved incidents
+                </span>
+              </div>
+            </article>
+          </section>
+
+          <section class="grid">
+            <article class="panel panel--chart">
+              <header class="panel__header">
+                <div>
+                  <h3>Sales trajectory</h3>
+                  <p>Daily certificate activations &amp; upgrades</p>
+                </div>
+                <button class="panel__action" type="button">
+                  <i class="fa-solid fa-ellipsis"></i>
+                </button>
+              </header>
+              <div class="chart chart--bar" role="img" aria-label="Bar chart showing the past seven days of sales"></div>
+              <footer class="panel__footer">
+                <div>
+                  <span class="badge badge--success">+18.2%</span>
+                  <p>Momentum continues with a new high on Tuesday.</p>
+                </div>
+                <ul class="legend">
+                  <li><span class="legend__swatch legend__swatch--primary"></span>New sales</li>
+                  <li><span class="legend__swatch legend__swatch--secondary"></span>Renewals</li>
+                </ul>
+              </footer>
+            </article>
+            <article class="panel panel--donut">
+              <header class="panel__header">
+                <div>
+                  <h3>Channel mix</h3>
+                  <p>Acquisition sources this week</p>
+                </div>
+                <button class="panel__action" type="button">
+                  <i class="fa-solid fa-ellipsis"></i>
+                </button>
+              </header>
+              <div class="chart chart--donut" role="img" aria-label="Donut chart showing channel distribution">
+                <div class="chart--donut__ring"></div>
+                <div class="chart--donut__label">
+                  <strong>100%</strong>
+                  <span>Orders</span>
+                </div>
+              </div>
+              <div class="channel-list">
+                <div class="channel-list__item">
+                  <span class="channel-list__swatch channel-list__swatch--primary"></span>
+                  <div>
+                    <h4>Apple Developer Portal</h4>
+                    <p>Direct license purchases from Apple partners</p>
+                  </div>
+                  <strong>38%</strong>
+                </div>
+                <div class="channel-list__item">
+                  <span class="channel-list__swatch channel-list__swatch--secondary"></span>
+                  <div>
+                    <h4>Affiliate Partners</h4>
+                    <p>Authorized agencies reselling certificates</p>
+                  </div>
+                  <strong>26%</strong>
+                </div>
+                <div class="channel-list__item">
+                  <span class="channel-list__swatch channel-list__swatch--tertiary"></span>
+                  <div>
+                    <h4>Enterprise Sales</h4>
+                    <p>Custom Apple Connect deployments</p>
+                  </div>
+                  <strong>22%</strong>
+                </div>
+                <div class="channel-list__item">
+                  <span class="channel-list__swatch channel-list__swatch--quaternary"></span>
+                  <div>
+                    <h4>Self-Serve Trials</h4>
+                    <p>Upgrades from developer sandbox provisioning</p>
+                  </div>
+                  <strong>14%</strong>
+                </div>
+              </div>
+            </article>
+          </section>
+
+          <section class="grid grid--two">
+            <article class="panel">
+              <header class="panel__header">
+                <div>
+                  <h3>Recent certificate orders</h3>
+                  <p>Top enterprise customers in the last 48 hours</p>
+                </div>
+                <button class="panel__action" type="button">
+                  <i class="fa-solid fa-ellipsis"></i>
+                </button>
+              </header>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Company</th>
+                      <th>Bundle ID</th>
+                      <th>Order value</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <div class="table__cell">
+                          <span class="avatar avatar--small">
+                            <img src="https://i.pravatar.cc/80?img=12" alt="" />
+                          </span>
+                          Horizon Labs
+                        </div>
+                      </td>
+                      <td>com.horizon.passport</td>
+                      <td>$18,400</td>
+                      <td><span class="badge badge--success">Provisioned</span></td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <div class="table__cell">
+                          <span class="avatar avatar--small">
+                            <img src="https://i.pravatar.cc/80?img=32" alt="" />
+                          </span>
+                          Aurora Security
+                        </div>
+                      </td>
+                      <td>com.aurora.vault</td>
+                      <td>$12,950</td>
+                      <td><span class="badge badge--pending">Awaiting CSR</span></td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <div class="table__cell">
+                          <span class="avatar avatar--small">
+                            <img src="https://i.pravatar.cc/80?img=25" alt="" />
+                          </span>
+                          Delta Robotics
+                        </div>
+                      </td>
+                      <td>com.delta.robotics</td>
+                      <td>$9,780</td>
+                      <td><span class="badge badge--success">Provisioned</span></td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <div class="table__cell">
+                          <span class="avatar avatar--small">
+                            <img src="https://i.pravatar.cc/80?img=54" alt="" />
+                          </span>
+                          Pangea Airlines
+                        </div>
+                      </td>
+                      <td>air.pangea.mobile</td>
+                      <td>$15,200</td>
+                      <td><span class="badge badge--warning">Awaiting Apple</span></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </article>
+            <article class="panel">
+              <header class="panel__header">
+                <div>
+                  <h3>Apple Connect API health</h3>
+                  <p>Realtime sync queues &amp; response latency</p>
+                </div>
+                <button class="panel__action" type="button">
+                  <i class="fa-solid fa-ellipsis"></i>
+                </button>
+              </header>
+              <ul class="status-list">
+                <li>
+                  <div>
+                    <h4>Certificates endpoint</h4>
+                    <p>Last 5 minutes</p>
+                  </div>
+                  <div class="status-list__metric">
+                    <strong>182 ms</strong>
+                    <span class="badge badge--success">Operational</span>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <h4>Device registrations</h4>
+                    <p>Queued for sync</p>
+                  </div>
+                  <div class="status-list__metric">
+                    <strong>16</strong>
+                    <span class="badge badge--pending">Monitoring</span>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <h4>Webhook delivery</h4>
+                    <p>Last 24h success rate</p>
+                  </div>
+                  <div class="status-list__metric">
+                    <strong>99.2%</strong>
+                    <span class="badge badge--success">Healthy</span>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <h4>Scheduled renewals</h4>
+                    <p>Next maintenance window</p>
+                  </div>
+                  <div class="status-list__metric">
+                    <strong>03:00 UTC</strong>
+                    <span class="badge badge--warning">Heads-up</span>
+                  </div>
+                </li>
+              </ul>
+            </article>
+          </section>
+
+          <section class="panel panel--activity">
+            <header class="panel__header">
+              <div>
+                <h3>Activity timeline</h3>
+                <p>Live Apple Connect sync events</p>
+              </div>
+              <button class="panel__action" type="button">
+                <i class="fa-solid fa-ellipsis"></i>
+              </button>
+            </header>
+            <ol class="timeline">
+              <li>
+                <span class="timeline__dot timeline__dot--success"></span>
+                <div>
+                  <h4>New MDM certificate issued</h4>
+                  <p>Issued to Aurora Security for bundle com.aurora.vault</p>
+                  <time datetime="2024-03-18T10:24">10:24 AM</time>
+                </div>
+              </li>
+              <li>
+                <span class="timeline__dot timeline__dot--info"></span>
+                <div>
+                  <h4>Device enrollment sync</h4>
+                  <p>19 devices pushed to Apple Configurator via API</p>
+                  <time datetime="2024-03-18T09:51">9:51 AM</time>
+                </div>
+              </li>
+              <li>
+                <span class="timeline__dot timeline__dot--warning"></span>
+                <div>
+                  <h4>CSR validation pending</h4>
+                  <p>Awaiting signed CSR from Pangea Airlines team</p>
+                  <time datetime="2024-03-18T09:12">9:12 AM</time>
+                </div>
+              </li>
+              <li>
+                <span class="timeline__dot timeline__dot--info"></span>
+                <div>
+                  <h4>Webhook retries resolved</h4>
+                  <p>27 deferred deliveries replayed successfully</p>
+                  <time datetime="2024-03-18T08:37">8:37 AM</time>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </main>
+      </div>
+    </div>
+
+    <div class="backdrop" data-backdrop></div>
+
+    <script>
+      const body = document.body;
+      const sidebar = document.querySelector('.sidebar');
+      const backdrop = document.querySelector('[data-backdrop]');
+      const menuToggles = [
+        ...document.querySelectorAll('.topbar__menu, .sidebar__menu-toggle')
+      ];
+      const dropdownGroups = document.querySelectorAll('[data-dropdown]');
+      const themeToggle = document.querySelector('[data-theme-toggle]');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      const THEME_STORAGE_KEY = 'tailadmin-theme';
+
+      function toggleSidebar() {
+        if (window.innerWidth > 1024) return;
+        const visible = !sidebar.classList.contains('sidebar--visible');
+        sidebar.classList.toggle('sidebar--visible', visible);
+        sidebar.setAttribute('aria-hidden', visible ? 'false' : 'true');
+        backdrop.classList.toggle('backdrop--visible', visible);
+      }
+
+      menuToggles.forEach((button) => {
+        button.addEventListener('click', toggleSidebar);
+      });
+
+      backdrop.addEventListener('click', () => {
+        if (sidebar.classList.contains('sidebar--visible')) {
+          sidebar.classList.remove('sidebar--visible');
+          sidebar.setAttribute('aria-hidden', 'true');
+          backdrop.classList.remove('backdrop--visible');
+        }
+      });
+
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 1024) {
+          sidebar.classList.remove('sidebar--visible');
+          sidebar.setAttribute('aria-hidden', 'false');
+          backdrop.classList.remove('backdrop--visible');
+        } else {
+          const isVisible = sidebar.classList.contains('sidebar--visible');
+          sidebar.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
+        }
+      });
+
+      dropdownGroups.forEach((group) => {
+        const button = group.querySelector('button');
+        button.addEventListener('click', () => {
+          const isOpen = group.classList.toggle('sidebar__group--open');
+          button.setAttribute('aria-expanded', String(isOpen));
+        });
+      });
+
+      function applyTheme(mode, persist = true) {
+        const resolvedMode = mode === 'dark' ? 'dark' : 'light';
+        body.classList.toggle('dark', resolvedMode === 'dark');
+        body.setAttribute('data-theme', resolvedMode);
+
+        if (themeToggle) {
+          themeToggle.setAttribute('aria-pressed', String(resolvedMode === 'dark'));
+          themeToggle.setAttribute(
+            'aria-label',
+            resolvedMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+          );
+
+          const icon = themeToggle.querySelector('i');
+          if (icon) {
+            icon.classList.toggle('fa-sun', resolvedMode === 'dark');
+            icon.classList.toggle('fa-moon', resolvedMode !== 'dark');
+          }
+        }
+
+        if (persist) {
+          localStorage.setItem(THEME_STORAGE_KEY, resolvedMode);
+        }
+      }
+
+      function initTheme() {
+        const stored = localStorage.getItem(THEME_STORAGE_KEY);
+
+        if (stored === 'dark' || stored === 'light') {
+          applyTheme(stored, false);
+          return;
+        }
+
+        applyTheme(prefersDark.matches ? 'dark' : 'light', false);
+      }
+
+      if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+          const nextMode = body.classList.contains('dark') ? 'light' : 'dark';
+          applyTheme(nextMode);
+        });
+      }
+
+      prefersDark.addEventListener('change', (event) => {
+        if (!localStorage.getItem(THEME_STORAGE_KEY)) {
+          applyTheme(event.matches ? 'dark' : 'light', false);
+        }
+      });
+
+      if (window.innerWidth <= 1024) {
+        sidebar.setAttribute('aria-hidden', 'true');
+      }
+
+      initTheme();
+    </script>
+  </body>
+</html>

--- a/admin-dashboard-cert/styles.css
+++ b/admin-dashboard-cert/styles.css
@@ -1,0 +1,1045 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg-muted: #f1f5f9;
+  --bg-surface: #ffffff;
+  --bg-surface-elevated: #f8fafc;
+  --bg-sidebar: #1c2434;
+  --bg-sidebar-muted: #111a2b;
+  --text-primary: #0f172a;
+  --text-muted: #64748b;
+  --text-inverse: #f8fafc;
+  --primary: #3c50e0;
+  --primary-bright: #6577ff;
+  --primary-soft: rgba(60, 80, 224, 0.16);
+  --primary-soft-strong: rgba(60, 80, 224, 0.28);
+  --success: #22c55e;
+  --warning: #f97316;
+  --pending: #38bdf8;
+  --danger: #ef4444;
+  --accent-secondary: #80caee;
+  --accent-tertiary: #f7c32e;
+  --accent-quaternary: #16a34a;
+  --border-color: rgba(15, 23, 42, 0.08);
+  --shadow-soft: 0 18px 40px -32px rgba(15, 23, 42, 0.24);
+  --shadow: 0 25px 55px -30px rgba(15, 23, 42, 0.32);
+  --topbar-bg: rgba(255, 255, 255, 0.9);
+  --sidebar-upgrade-bg: rgba(60, 80, 224, 0.18);
+  --icon-glow: rgba(60, 80, 224, 0.12);
+  --channel-card-bg: rgba(255, 255, 255, 0.88);
+  --chart-bar-bg: linear-gradient(180deg, rgba(60, 80, 224, 0.18) 0%, rgba(60, 80, 224, 0.05) 100%);
+  --chart-bar-grid-primary: rgba(15, 23, 42, 0.06);
+  --chart-bar-grid-secondary: rgba(148, 163, 184, 0.16);
+  --chart-bar-column: rgba(60, 80, 224, 0.35);
+}
+
+body.dark {
+  --bg-muted: #0b1220;
+  --bg-surface: #111c2d;
+  --bg-surface-elevated: #18233a;
+  --bg-sidebar: #070d1c;
+  --bg-sidebar-muted: #0f172a;
+  --text-primary: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-inverse: #f8fafc;
+  --primary: #6577ff;
+  --primary-bright: #8e9bff;
+  --primary-soft: rgba(101, 119, 255, 0.22);
+  --primary-soft-strong: rgba(101, 119, 255, 0.34);
+  --success: #34d399;
+  --warning: #fb923c;
+  --pending: #38bdf8;
+  --danger: #f87171;
+  --accent-secondary: #80caee;
+  --accent-tertiary: #facc15;
+  --accent-quaternary: #22c55e;
+  --border-color: rgba(148, 163, 184, 0.16);
+  --shadow-soft: 0 20px 50px -30px rgba(3, 7, 18, 0.7);
+  --shadow: 0 30px 60px -28px rgba(2, 6, 23, 0.72);
+  --topbar-bg: rgba(11, 18, 32, 0.94);
+  --sidebar-upgrade-bg: rgba(101, 119, 255, 0.24);
+  --icon-glow: rgba(101, 119, 255, 0.2);
+  --channel-card-bg: rgba(24, 35, 58, 0.9);
+  --chart-bar-bg: linear-gradient(180deg, rgba(101, 119, 255, 0.24) 0%, rgba(101, 119, 255, 0.1) 100%);
+  --chart-bar-grid-primary: rgba(148, 163, 184, 0.22);
+  --chart-bar-grid-secondary: rgba(51, 65, 85, 0.4);
+  --chart-bar-column: rgba(101, 119, 255, 0.45);
+}
+
+body {
+  margin: 0;
+  background: var(--bg-muted);
+  color: var(--text-primary);
+  font-family: "SF Pro Text", "SF Pro Display", "SF Pro Icons", -apple-system,
+    BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  min-height: 100vh;
+  transition: background-color 0.35s ease, color 0.35s ease;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+  border: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+img {
+  display: block;
+  width: 100%;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+  background: var(--bg-muted);
+}
+
+.sidebar {
+  background: linear-gradient(180deg, var(--bg-sidebar) 0%, var(--bg-sidebar-muted) 100%);
+  color: var(--text-inverse);
+  padding: 24px 20px 32px;
+  position: relative;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  transition: background 0.35s ease, color 0.35s ease;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.sidebar__menu-toggle {
+  display: none;
+  color: var(--text-inverse);
+  font-size: 1.25rem;
+}
+
+.sidebar__logo-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar__logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+}
+
+.sidebar__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-inverse);
+}
+
+.sidebar__scroll {
+  overflow-y: auto;
+  flex: 1;
+  padding-right: 4px;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar__section {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 252, 0.6);
+  margin: 0 0 4px 14px;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  color: rgba(248, 250, 252, 0.85);
+  transition: background 0.2s ease, color 0.2s ease;
+  font-weight: 500;
+}
+
+.sidebar__link:hover,
+.sidebar__link:focus {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-inverse);
+}
+
+.sidebar__link--active {
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--text-inverse);
+}
+
+.sidebar__icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.95rem;
+}
+
+.sidebar__link--dropdown {
+  width: 100%;
+  text-align: left;
+}
+
+.sidebar__chevron {
+  margin-left: auto;
+  transition: transform 0.25s ease;
+}
+
+.sidebar__group:not(.sidebar__group--open) .sidebar__submenu {
+  max-height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.sidebar__group--open .sidebar__submenu {
+  max-height: 240px;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.sidebar__group--open .sidebar__chevron {
+  transform: rotate(180deg);
+}
+
+.sidebar__submenu {
+  display: grid;
+  gap: 4px;
+  margin-top: 8px;
+  padding-left: 46px;
+  transition: max-height 0.3s ease, opacity 0.2s ease;
+}
+
+.sidebar__sublink {
+  font-size: 0.9rem;
+  color: rgba(248, 250, 252, 0.7);
+  padding: 8px 10px;
+  border-radius: 8px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__sublink:hover,
+.sidebar__sublink:focus {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-inverse);
+}
+
+.sidebar__sublink--active {
+  color: var(--text-inverse);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.sidebar__upgrade {
+  margin-top: 28px;
+  padding: 18px 16px;
+  border-radius: 16px;
+  background: var(--sidebar-upgrade-bg);
+  display: grid;
+  gap: 10px;
+  color: var(--text-inverse);
+  transition: background-color 0.35s ease, color 0.35s ease;
+}
+
+.sidebar__upgrade h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.sidebar__upgrade p {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: rgba(248, 250, 252, 0.8);
+}
+
+.sidebar__upgrade button {
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--text-inverse);
+  color: var(--bg-sidebar);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.workspace {
+  background: linear-gradient(180deg, var(--bg-muted) 0%, var(--bg-surface) 100%);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  transition: background 0.35s ease;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 32px;
+  background: var(--topbar-bg);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  transition: background-color 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.topbar__menu {
+  display: none;
+  font-size: 1.25rem;
+  color: var(--text-muted);
+}
+
+body.dark .topbar {
+  background: var(--topbar-bg);
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: 0 1px 0 rgba(2, 8, 21, 0.6);
+}
+
+.search {
+  flex: 1;
+  max-width: 420px;
+  background: var(--bg-muted);
+  border-radius: 999px;
+  padding: 9px 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--border-color);
+  transition: background-color 0.35s ease, border-color 0.35s ease;
+}
+
+.search input {
+  border: 0;
+  background: transparent;
+  outline: none;
+  width: 100%;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.search i {
+  color: var(--text-muted);
+}
+
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.topbar__button {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--bg-surface-elevated);
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.topbar__button:hover {
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+.avatar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--bg-surface-elevated);
+  padding: 4px 12px 4px 4px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.avatar:hover {
+  background: var(--primary-soft);
+}
+
+.avatar img {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+}
+
+.avatar span {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.3;
+}
+
+.avatar strong {
+  font-size: 0.95rem;
+}
+
+.avatar small {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.main {
+  padding: 40px 32px 48px;
+  display: grid;
+  gap: 28px;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.main__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.main__header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 1.6rem + 1vw, 2.4rem);
+  letter-spacing: -0.01em;
+}
+
+.main__header p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 560px;
+}
+
+.primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-bright) 100%);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 18px 34px -18px rgba(10, 132, 255, 0.45);
+  transition: background 0.35s ease, box-shadow 0.35s ease;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.stat-card {
+  background: var(--bg-surface);
+  border-radius: 20px;
+  padding: 26px 28px;
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid var(--border-color);
+  transition: background-color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.stat-card__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, var(--primary-soft-strong), var(--icon-glow));
+  color: var(--primary);
+  font-size: 1.35rem;
+  transition: background 0.35s ease, color 0.35s ease;
+}
+
+.stat-card__meta h2 {
+  margin: 0;
+  font-size: clamp(1.9rem, 1.7rem + 0.5vw, 2.2rem);
+}
+
+.stat-card__meta p {
+  margin: 6px 0 12px;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.stat-card__delta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+}
+
+.stat-card__delta--up {
+  background: rgba(50, 215, 75, 0.16);
+  color: var(--success);
+}
+
+.stat-card__delta--down {
+  background: rgba(255, 69, 58, 0.16);
+  color: var(--danger);
+}
+
+.grid {
+  display: grid;
+  gap: 20px;
+}
+
+.grid--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid:not(.grid--two) {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.panel {
+  background: var(--bg-surface);
+  border-radius: 22px;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  transition: background-color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 24px 28px 0;
+}
+
+.panel__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.panel__header p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.panel__action {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--bg-surface-elevated);
+  color: var(--text-muted);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.panel__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 28px 24px;
+  flex-wrap: wrap;
+}
+
+.panel__footer p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.panel--chart .chart {
+  padding: 24px 28px;
+}
+
+.chart--bar {
+  min-height: 240px;
+  border-radius: 18px;
+  background: var(--chart-bar-bg);
+  position: relative;
+  overflow: hidden;
+  transition: background 0.35s ease;
+}
+
+.chart--bar::before {
+  content: "";
+  position: absolute;
+  inset: 24px 24px 32px;
+  background-image: linear-gradient(
+      to right,
+      var(--chart-bar-grid-primary) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to top,
+      var(--chart-bar-grid-secondary) 1px,
+      transparent 1px
+    );
+  background-size: 48px 100%, 100% 48px;
+  opacity: 0.4;
+}
+
+.chart--bar::after {
+  content: "";
+  position: absolute;
+  inset: auto 24px 24px;
+  height: 180px;
+  background-image: linear-gradient(
+    to right,
+    var(--chart-bar-column) 28px,
+    transparent 28px
+  );
+  background-size: 64px 1px;
+  background-repeat: repeat-x;
+  background-position: left bottom;
+}
+
+.chart--donut {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 0 auto;
+  display: grid;
+  place-items: center;
+}
+
+.chart--donut__ring {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--primary) 0 38%,
+    var(--accent-secondary) 38% 64%,
+    var(--accent-tertiary) 64% 86%,
+    var(--accent-quaternary) 86% 100%
+  );
+  mask: radial-gradient(circle at center, transparent 52%, black 53%);
+}
+
+.chart--donut__label {
+  position: absolute;
+  text-align: center;
+  color: var(--text-primary);
+}
+
+.channel-list {
+  display: grid;
+  gap: 16px;
+  padding: 0 28px 28px;
+}
+
+.channel-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 20px;
+  border-radius: 18px;
+  background: var(--channel-card-bg);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-soft);
+  transition: background-color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.channel-list__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+}
+
+.channel-list__swatch--primary {
+  background: var(--primary);
+}
+
+.channel-list__swatch--secondary {
+  background: var(--accent-secondary);
+}
+
+.channel-list__swatch--tertiary {
+  background: var(--accent-tertiary);
+}
+
+.channel-list__swatch--quaternary {
+  background: var(--accent-quaternary);
+}
+
+.channel-list__item h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.channel-list__item p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.table-wrapper {
+  padding: 0 28px 28px;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.95rem;
+}
+
+th {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.table__cell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar--small img {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.badge--success {
+  background: rgba(50, 215, 75, 0.18);
+  color: var(--success);
+}
+
+.badge--warning {
+  background: rgba(255, 159, 10, 0.2);
+  color: var(--warning);
+}
+
+.badge--pending {
+  background: rgba(90, 200, 250, 0.2);
+  color: var(--pending);
+}
+
+.legend {
+  display: flex;
+  gap: 18px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.legend__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  display: inline-block;
+  margin-right: 8px;
+}
+
+.legend__swatch--primary {
+  background: var(--primary);
+}
+
+.legend__swatch--secondary {
+  background: var(--accent-secondary);
+}
+
+.status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 28px 28px;
+  display: grid;
+  gap: 18px;
+}
+
+.status-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-list h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.status-list p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.status-list__metric {
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0 28px 32px;
+  display: grid;
+  gap: 22px;
+}
+
+.timeline li {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 16px;
+}
+
+.timeline__dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-top: 4px;
+}
+
+.timeline__dot--success {
+  background: var(--success);
+}
+
+.timeline__dot--info {
+  background: var(--primary);
+}
+
+.timeline__dot--warning {
+  background: var(--warning);
+}
+
+.timeline h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.timeline p {
+  margin: 4px 0 8px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+time {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.panel--activity {
+  padding-bottom: 8px;
+}
+
+.panel--donut {
+  align-items: center;
+  text-align: center;
+}
+
+.panel--donut .panel__header,
+.panel--donut .panel__footer {
+  width: 100%;
+}
+
+.panel--donut .panel__header {
+  padding-bottom: 20px;
+}
+
+.panel--donut .channel-list {
+  width: 100%;
+}
+
+.badge--success,
+.badge--pending,
+.badge--warning {
+  box-shadow: none;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 20;
+}
+
+.backdrop--visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.sidebar__group.sidebar__group--open .sidebar__chevron {
+  transform: rotate(180deg);
+}
+
+@media (max-width: 1280px) {
+  .stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .grid,
+  .grid--two {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1024px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: 280px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+  }
+
+  .sidebar.sidebar--visible {
+    transform: translateX(0);
+  }
+
+  .sidebar__menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    background: rgba(15, 23, 42, 0.35);
+  }
+
+  .topbar__menu {
+    display: inline-flex;
+  }
+
+  .workspace {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .topbar {
+    padding: 16px 20px;
+  }
+
+  .topbar__actions {
+    gap: 10px;
+  }
+
+  .avatar span {
+    display: none;
+  }
+
+  .main {
+    padding: 24px 20px 32px;
+  }
+
+  .stats {
+    grid-template-columns: 1fr;
+  }
+
+  .primary {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .channel-list__item {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .search {
+    max-width: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .topbar {
+    flex-wrap: wrap;
+  }
+
+  .search {
+    order: 3;
+    width: 100%;
+  }
+
+  .topbar__actions {
+    order: 2;
+  }
+
+  .topbar__menu {
+    order: 1;
+  }
+
+  .main__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- retune the admin certificate dashboard color tokens to match TailAdmin's analytics palette across light and dark themes
- refresh sidebar, topbar, and chart background variables so the UI inherits the new blue-forward aesthetic

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68db5444454c8329afd40bdd71306104